### PR TITLE
Fix for string not decoding properly

### DIFF
--- a/src/tools/base64/main.ts
+++ b/src/tools/base64/main.ts
@@ -7,7 +7,7 @@ $('#text-decoded').on('input', ev => {
 
 $('#text-encoded').on('input', ev => {
     const target = ev.target as HTMLInputElement;
-    $('#text-encoded').val(atob(target.value));
+    $('#text-decoded').val(atob(target.value));
 });
 
 const initialText = 'Try it out !';


### PR DESCRIPTION
PR Description: 
 For tool Base64 Encoder/Decoder, string decode function was not working correctly. 
 Issue was raised here: [#1](https://github.com/AbdealiJK/browser-tools/issues/1)